### PR TITLE
Added Product model

### DIFF
--- a/src/Congo.WebApi/Congo.WebApi.csproj
+++ b/src/Congo.WebApi/Congo.WebApi.csproj
@@ -1,10 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.9">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
   </ItemGroup>
 

--- a/src/Congo.WebApi/Models/ProductModel.cs
+++ b/src/Congo.WebApi/Models/ProductModel.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Congo.WebApi.Models
+{
+    public class ProductModel
+    {
+        public string Name{ get; set; }
+        public string ID { get; set; }
+        public string Description { get; set; }
+        public decimal Price { get; set; }
+        public string ImgUri { get; set; }
+    }
+}


### PR DESCRIPTION
Starting simple. Added the product model from the examples we discussed in discord.
 The reason for the ID being a string is so we can encode the ID in base64.