### PR TITLE
Added support for JetBrains Rider users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
+.idea/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 


### PR DESCRIPTION
Similar to the `.vscode` and `.vs` directories, the `.idea` directory should be ignored by git. This change in the `.gitignore` file realizes this.

Resolves #33