### PR TITLE
Unified the API contracts

### DIFF
--- a/src/Congo.Contracts/Responses/Orders/OrderConfirmationResponse.cs
+++ b/src/Congo.Contracts/Responses/Orders/OrderConfirmationResponse.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Congo.Contracts.Responses.Orders
+{
+    public sealed class OrderConfirmationResponse
+    {
+        public Guid OrderId { get; init; }
+    }
+}

--- a/src/Congo.WebApi/Congo.WebApi.csproj
+++ b/src/Congo.WebApi/Congo.WebApi.csproj
@@ -5,15 +5,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="MediatR" Version="9.0.0" />
+    <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>   
+    </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Congo.Contracts\Congo.Contracts.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Congo.WebApi/Contracts/Responses/OrderConfirmationResponse.cs
+++ b/src/Congo.WebApi/Contracts/Responses/OrderConfirmationResponse.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace Congo.WebApi.Contracts.Responses
-{
-    public class OrderConfirmationResponse
-    {
-        public Guid OrderId { get; init; }
-    }
-}

--- a/src/Congo.WebApi/Controllers/ProductsController.cs
+++ b/src/Congo.WebApi/Controllers/ProductsController.cs
@@ -1,11 +1,11 @@
-﻿using Congo.WebApi.Contracts.Responses;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Congo.Contracts.Responses.Orders;
 using Congo.WebApi.Data.Models;
 using Congo.WebApi.Data.ProductAccess;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace Congo.WebApi.Controllers
 {
@@ -17,7 +17,7 @@ namespace Congo.WebApi.Controllers
 
         public ProductsController(IMediator mediator)
         {
-           _mediator = mediator;
+            _mediator = mediator;
         }
 
         [HttpGet]


### PR DESCRIPTION
- Moved the OrderConfirmationResponse to the Contracts project
- Adjusted the namespace for OrderConfirmationResponse
- Sealed OrderConfirmationResponse in accordance with the rest of the contracts (this should not be an issue, since it has not been used anywhere yet)
- Referenced the Contracts project in the WebApi project
- Removed the now empty contracts directory in the WebApi project

Resolves #38 