### PR TITLE
Implement CORS for WebAPI project

### DIFF
--- a/src/Congo.WebApi/Startup.cs
+++ b/src/Congo.WebApi/Startup.cs
@@ -37,16 +37,19 @@ namespace Congo.WebApi
 
                 options.AddPolicy(_CORS_PROD, policy =>
                 {
-                    //TODO: Multiple Origins from env vars
+                    // TODO: Multiple Origins from env vars
                     string ALLOWED_ORIGIN = Environment.GetEnvironmentVariable("ALLOWED_ORIGIN");
-                    if (ALLOWED_ORIGIN != null)
+
+                    if (!string.IsNullOrWhiteSpace(ALLOWED_ORIGIN))
                     {
                         //Debug.WriteLine("ALLOWED_ORIGIN = " + ALLOWED_ORIGIN);
                         policy.WithOrigins(ALLOWED_ORIGIN).AllowAnyMethod().AllowAnyHeader();
                     }
                     else if (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") != "Development")
-                        // to prevent this exception in dev env
-                        throw new Exception("No value set for env ALLOWED_ORIGIN.");
+                    {
+                        // by default, this exception is thrown even in dev env without the above check
+                        throw new Exception("No value set for mandatory environment variable ALLOWED_ORIGIN.");
+                    }
                 });
             });
             services.AddSwaggerGen(c =>
@@ -60,6 +63,8 @@ namespace Congo.WebApi
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            // https://docs.microsoft.com/en-us/aspnet/core/fundamentals/middleware/?view=aspnetcore-5.0#middleware-order-1
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
@@ -71,7 +76,6 @@ namespace Congo.WebApi
 
             app.UseRouting();
 
-            // https://docs.microsoft.com/en-us/aspnet/core/fundamentals/middleware/?view=aspnetcore-5.0#middleware-order-1
             app.UseCors(env.IsDevelopment() ? _CORS_DEV : _CORS_PROD);
 
             app.UseAuthorization();

--- a/src/Congo.WebApi/Startup.cs
+++ b/src/Congo.WebApi/Startup.cs
@@ -32,23 +32,21 @@ namespace Congo.WebApi
 
             services.AddCors(options =>
             {
-                //DEV
                 options.AddPolicy(_CORS_DEV, policy =>
                             policy.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader());
 
-                //PROD
-                //TODO: Multiple Origins from env vars
                 options.AddPolicy(_CORS_PROD, policy =>
                 {
+                    //TODO: Multiple Origins from env vars
                     string ALLOWED_ORIGIN = Environment.GetEnvironmentVariable("ALLOWED_ORIGIN");
                     if (ALLOWED_ORIGIN != null)
                     {
-                        //Debug.WriteLine("ALLOWED_ORIGIN = " + x);
+                        //Debug.WriteLine("ALLOWED_ORIGIN = " + ALLOWED_ORIGIN);
                         policy.WithOrigins(ALLOWED_ORIGIN).AllowAnyMethod().AllowAnyHeader();
                     }
-                    else if(Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") != "Development")
-                        // to prevent this error in dev env
-                        throw new Exception("No Environment variable value set for ALLOWED_ORIGIN");
+                    else if (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") != "Development")
+                        // to prevent this exception in dev env
+                        throw new Exception("No value set for env ALLOWED_ORIGIN.");
                 });
             });
             services.AddSwaggerGen(c =>
@@ -67,23 +65,14 @@ namespace Congo.WebApi
                 app.UseDeveloperExceptionPage();
                 app.UseSwagger();
                 app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Congo.WebApi v1"));
-                app.UseCors(config => config.WithOrigins("*").AllowAnyMethod().AllowAnyHeader());
             }
 
             app.UseHttpsRedirection();
 
             app.UseRouting();
 
-            // Middleware is ordered
             // https://docs.microsoft.com/en-us/aspnet/core/fundamentals/middleware/?view=aspnetcore-5.0#middleware-order-1
-            if (env.IsDevelopment())
-            {
-                app.UseCors(_CORS_DEV);
-            }
-            else
-            {
-                app.UseCors(_CORS_PROD);
-            }
+            app.UseCors(env.IsDevelopment() ? _CORS_DEV : _CORS_PROD);
 
             app.UseAuthorization();
 

--- a/src/Congo.WebApi/Startup.cs
+++ b/src/Congo.WebApi/Startup.cs
@@ -47,7 +47,7 @@ namespace Congo.WebApi
                     }
                     else if (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") != "Development")
                     {
-                        // by default, this exception is thrown even in dev env without the above check
+                        // Don't throw any exceptions in development, as this policy should only be used in production
                         throw new Exception("No value set for mandatory environment variable ALLOWED_ORIGIN.");
                     }
                 });


### PR DESCRIPTION
Closes #73 

The WebAPI
- In `Development` env - Can be accessible from any origin
- In `Production` env - Environment variable ALLOWED_ORIGIN can be set to Enable CORS for that specific origin.

#### In Future (If needed)
- Allow Multiple Origins to be set from env-var (during hosting)