### PR TITLE
remove duplicate project reference in razor proj

### DIFF
--- a/src/Congo.RazorPages/Congo.RazorPages.csproj
+++ b/src/Congo.RazorPages/Congo.RazorPages.csproj
@@ -15,8 +15,4 @@
     <ProjectReference Include="..\Congo.Contracts\Congo.Contracts.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Congo.Contracts\Congo.Contracts.csproj" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
There were two identical project references inside the razorpages.csproj file. This PR will remove one of them.